### PR TITLE
update the link to open concore-editor

### DIFF
--- a/editgraph
+++ b/editgraph
@@ -2,13 +2,13 @@
 which open
 if [ $? == 0 ] 
 then
-   open https://controlcore-project.github.io/DHGWorkflow/
+   open https://controlcore-project.github.io/concore-editor/
 else
    which xdg-open
    if [ $? == 0 ] 
    then
-      xdg-open https://controlcore-project.github.io/DHGWorkflow/
+      xdg-open https://controlcore-project.github.io/concore-editor/
    else
-      echo "unable to open browser for DHGWorkflow"
+      echo "unable to open browser for concore-editor"
    fi
 fi

--- a/editgraph.bat
+++ b/editgraph.bat
@@ -1,2 +1,2 @@
-start https://controlcore-project.github.io/DHGWorkflow/
+start https://controlcore-project.github.io/concore-editor/
 


### PR DESCRIPTION
I have updated the link to open concore editor to https://controlcore-project.github.io/concore-editor/ which is our latest stably deployed version for concore-editor. This fixes #6 